### PR TITLE
Start Server Auth - Support Magical Auth Flow That Started At BE

### DIFF
--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -71,11 +71,14 @@ type UserIdentifier interface {
 //magic auth
 
 type MagicAuthStartProps struct {
-	Email           string     `json:"email,omitempty"`
-	PhoneNumber     string     `json:"phoneNumber,omitempty"`
-	State           string     `json:"state,omitempty"`
-	RedirectURL     string     `json:"redirectURL,omitempty"`
-	FallbackChannel NoFallback `json:"fallbackChannel,omitempty"`
+	Email              string     `json:"email,omitempty"`
+	PhoneNumber        string     `json:"phoneNumber,omitempty"`
+	State              string     `json:"state,omitempty"`
+	RedirectURL        string     `json:"redirectUrl,omitempty"`
+	FallbackChannel    NoFallback `json:"fallbackChannel,omitempty"`
+	DeviceIPAddress    string     `json:"deviceIpAddress,omitempty"`
+	OTPConfirmationURL string     `json:"otpConfirmationUrl,omitempty"`
+	RCSConfirmationURL string     `json:"rcsConfirmationUrl,omitempty"`
 }
 
 type NoFallback string
@@ -88,10 +91,21 @@ const (
 )
 
 type MagicAuthVerifyProps struct {
-	Email       string `json:"email,omitempty"`
-	PhoneNumber string `json:"phoneNumber,omitempty"`
-	Code        string `json:"code,omitempty"`
-	Token       string `json:"token,omitempty"`
+	Email           string `json:"email,omitempty"`
+	PhoneNumber     string `json:"phoneNumber,omitempty"`
+	Code            string `json:"code,omitempty"`
+	Token           string `json:"token,omitempty"`
+	DeviceIPAddress string `json:"deviceIpAddress,omitempty"`
+}
+
+type MagicAuthStartServerAuthResponse struct {
+	SessionID string `json:"sessionId"`
+	AuthURL   string `json:"authUrl"`
+}
+
+type MagicAuthCheckServerAuthResponse struct {
+	Status   string `json:"status"` // "PENDING" or "COMPLETED"
+	Verified bool   `json:"verified"`
 }
 
 // number verify


### PR DESCRIPTION
1. Now with the new functions `StartServerAuth ` & `CheckServerAuth ` we are able to initiate the verification flow from a BE request (Server)
2. `DeviceIPAddress ` Parameter was added to the original `StartAuth` & `VerifyAuth` methods, so that the IP address of the device could be passed to override the address from the request to enable the same functionality for both FE & BE flows